### PR TITLE
Add gyro constructors to pass in the base object

### DIFF
--- a/src/main/java/frc/team88/swerve/gyro/NavX.java
+++ b/src/main/java/frc/team88/swerve/gyro/NavX.java
@@ -19,6 +19,15 @@ public class NavX implements SwerveGyro {
   }
 
   /**
+   * Constructor. Uses the given AHRS object instead of constructing a new one.
+   *
+   * @param base The AHRS object to base this object on.
+   */
+  public NavX(AHRS base) {
+    this.base = base;
+  }
+
+  /**
    * Construct. Uses the given SPI port.
    *
    * @param port The SPI port

--- a/src/main/java/frc/team88/swerve/gyro/Pigeon.java
+++ b/src/main/java/frc/team88/swerve/gyro/Pigeon.java
@@ -19,7 +19,7 @@ public class Pigeon implements SwerveGyro {
   /**
    * Constructor. Uses the given PigeonIMU object instead of constructing a new one.
    *
-   * @param base The AHRS object to base this object on.
+   * @param base The PigeonIMU object to base this object on.
    */
   public Pigeon(PigeonIMU base) {
     this.base = base;

--- a/src/main/java/frc/team88/swerve/gyro/Pigeon.java
+++ b/src/main/java/frc/team88/swerve/gyro/Pigeon.java
@@ -17,6 +17,15 @@ public class Pigeon implements SwerveGyro {
   }
 
   /**
+   * Constructor. Uses the given PigeonIMU object instead of constructing a new one.
+   *
+   * @param base The AHRS object to base this object on.
+   */
+  public Pigeon(PigeonIMU base) {
+    this.base = base;
+  }
+
+  /**
    * Construct. Uses the given CAN ID.
    *
    * @param id The CAN ID


### PR DESCRIPTION
This allows teams to retain access to the base gyro object, in case they want to use features that the SwerveGyro interface doesn't provide access to.

Closes #102 