### PR TITLE
Frc 88/azimuth flip

### DIFF
--- a/src/main/java/frc/team88/swerve/SwerveController.java
+++ b/src/main/java/frc/team88/swerve/SwerveController.java
@@ -4,6 +4,7 @@ import com.ctre.phoenix.CANifier;
 import frc.team88.swerve.configuration.Configuration;
 import frc.team88.swerve.data.DataManager;
 import frc.team88.swerve.gyro.SwerveGyro;
+import frc.team88.swerve.module.ModuleDoubleSupplier;
 import frc.team88.swerve.motion.SwerveChassis;
 import frc.team88.swerve.motion.state.OdomState;
 import frc.team88.swerve.motion.state.VelocityState;
@@ -195,6 +196,25 @@ public class SwerveController {
   /** Sets all motors on the swerve drive to brake. This is the default behavior. */
   public void setBrake() {
     this.chassis.setBrake();
+  }
+
+  /**
+   * Sets strategy for azimuth flipping for all modules
+   * 
+   * @return
+   */
+  public void setAzimuthWrapBiasStrategy(ModuleDoubleSupplier supplier) {
+    this.chassis.setAzimuthWrapBiasStrategy(supplier);
+  }
+
+
+  /**
+   * Sets strategy for azimuth flipping for a single module
+   * 
+   * @return
+   */
+  public void setAzimuthWrapBiasStrategy(int moduleIndex, ModuleDoubleSupplier supplier) {
+    this.chassis.setAzimuthWrapBiasStrategy(moduleIndex, supplier);
   }
 
   /**

--- a/src/main/java/frc/team88/swerve/SwerveController.java
+++ b/src/main/java/frc/team88/swerve/SwerveController.java
@@ -4,7 +4,7 @@ import com.ctre.phoenix.CANifier;
 import frc.team88.swerve.configuration.Configuration;
 import frc.team88.swerve.data.DataManager;
 import frc.team88.swerve.gyro.SwerveGyro;
-import frc.team88.swerve.module.ModuleDoubleSupplier;
+import frc.team88.swerve.module.util.ModuleDoubleSupplier;
 import frc.team88.swerve.motion.SwerveChassis;
 import frc.team88.swerve.motion.state.OdomState;
 import frc.team88.swerve.motion.state.VelocityState;
@@ -200,18 +200,20 @@ public class SwerveController {
 
   /**
    * Sets strategy for azimuth flipping for all modules
-   * 
-   * @return
+   *
+   * @param supplier A lambda function of type ModuleDoubleSupplier. Takes a module, returns bias as
+   *     double
    */
   public void setAzimuthWrapBiasStrategy(ModuleDoubleSupplier supplier) {
     this.chassis.setAzimuthWrapBiasStrategy(supplier);
   }
 
-
   /**
    * Sets strategy for azimuth flipping for a single module
-   * 
-   * @return
+   *
+   * @param moduleIndex index of module to set
+   * @param supplier A lambda function of type ModuleDoubleSupplier. Takes a module, returns bias as
+   *     double
    */
   public void setAzimuthWrapBiasStrategy(int moduleIndex, ModuleDoubleSupplier supplier) {
     this.chassis.setAzimuthWrapBiasStrategy(moduleIndex, supplier);

--- a/src/main/java/frc/team88/swerve/module/ModuleDoubleSupplier.java
+++ b/src/main/java/frc/team88/swerve/module/ModuleDoubleSupplier.java
@@ -1,5 +1,0 @@
-package frc.team88.swerve.module;
-
-public interface ModuleDoubleSupplier {
-    double getAsDouble(SwerveModule module);
-}

--- a/src/main/java/frc/team88/swerve/module/ModuleDoubleSupplier.java
+++ b/src/main/java/frc/team88/swerve/module/ModuleDoubleSupplier.java
@@ -1,0 +1,5 @@
+package frc.team88.swerve.module;
+
+public interface ModuleDoubleSupplier {
+    double getAsDouble(SwerveModule module);
+}

--- a/src/main/java/frc/team88/swerve/module/SwerveModule.java
+++ b/src/main/java/frc/team88/swerve/module/SwerveModule.java
@@ -4,13 +4,13 @@ import edu.wpi.first.wpiutil.math.Pair;
 import frc.team88.swerve.configuration.subconfig.SwerveModuleConfiguration;
 import frc.team88.swerve.module.motor.SwerveMotor;
 import frc.team88.swerve.module.sensor.PositionSensor;
+import frc.team88.swerve.module.util.ModuleDoubleSupplier;
 import frc.team88.swerve.util.MathUtils;
 import frc.team88.swerve.util.SyncPIDController;
 import frc.team88.swerve.util.TrapezoidalProfileController;
 import frc.team88.swerve.util.Vector2D;
 import frc.team88.swerve.util.WrappedAngle;
 import java.util.Objects;
-import java.util.function.DoubleSupplier;
 import java.util.stream.Stream;
 import org.apache.commons.math3.linear.RealMatrix;
 
@@ -402,6 +402,9 @@ public class SwerveModule {
 
   /**
    * Sets strategy for azimuth flipping for a module
+   *
+   * @param supplier A lambda function of type ModuleDoubleSupplier. Takes a module, returns bias as
+   *     double
    */
   public void setAzimuthWrapBiasStrategy(ModuleDoubleSupplier supplier) {
     this.azimuthWrapBiasStrategy = supplier;
@@ -409,9 +412,12 @@ public class SwerveModule {
 
   /**
    * The default strategy for azimuth flipping for a module (default behavior is always flip)
+   *
+   * @param module an object of type SwerveModule
+   * @return Azimuth flip bias
    */
   public double defaultAzimuthWrapBiasStrategy(SwerveModule module) {
-    return 90;  // 90 = always flip azimuth. 180 = never flip azimuth
+    return 90; // 90 = always flip azimuth. 180 = never flip azimuth
   }
 
   /**

--- a/src/main/java/frc/team88/swerve/module/util/ModuleDoubleSupplier.java
+++ b/src/main/java/frc/team88/swerve/module/util/ModuleDoubleSupplier.java
@@ -1,0 +1,8 @@
+package frc.team88.swerve.module.util;
+
+import frc.team88.swerve.module.SwerveModule;
+
+/** A lambda function that takes a module and returns a double */
+public interface ModuleDoubleSupplier {
+  double getAsDouble(SwerveModule module);
+}

--- a/src/main/java/frc/team88/swerve/motion/SwerveChassis.java
+++ b/src/main/java/frc/team88/swerve/motion/SwerveChassis.java
@@ -1,6 +1,7 @@
 package frc.team88.swerve.motion;
 
 import frc.team88.swerve.configuration.Configuration;
+import frc.team88.swerve.module.ModuleDoubleSupplier;
 import frc.team88.swerve.module.SwerveModule;
 import frc.team88.swerve.motion.kinematics.ForwardKinematics;
 import frc.team88.swerve.motion.kinematics.InverseKinematics;
@@ -177,6 +178,26 @@ public class SwerveChassis {
   public void setBrake() {
     Stream.of(this.config.getModules()).forEach(m -> m.setBrake());
   }
+
+  /**
+   * Sets strategy for azimuth flipping for all modules
+   * 
+   * @return
+   */
+  public void setAzimuthWrapBiasStrategy(ModuleDoubleSupplier supplier) {
+    Stream.of(this.config.getModules()).forEach(m -> m.setAzimuthWrapBiasStrategy(supplier));
+  }
+
+  /**
+   * Sets strategy for azimuth flipping for a single module
+   * 
+   * @return
+   */
+  public void setAzimuthWrapBiasStrategy(int moduleIndex, ModuleDoubleSupplier supplier) {
+      SwerveModule module = this.config.getModules()[moduleIndex];
+      module.setAzimuthWrapBiasStrategy(supplier);
+  }
+
 
   /**
    * Gets the maximum translation speed if the drive is doing nothing else.

--- a/src/main/java/frc/team88/swerve/motion/SwerveChassis.java
+++ b/src/main/java/frc/team88/swerve/motion/SwerveChassis.java
@@ -1,8 +1,8 @@
 package frc.team88.swerve.motion;
 
 import frc.team88.swerve.configuration.Configuration;
-import frc.team88.swerve.module.ModuleDoubleSupplier;
 import frc.team88.swerve.module.SwerveModule;
+import frc.team88.swerve.module.util.ModuleDoubleSupplier;
 import frc.team88.swerve.motion.kinematics.ForwardKinematics;
 import frc.team88.swerve.motion.kinematics.InverseKinematics;
 import frc.team88.swerve.motion.state.ModuleState;
@@ -181,8 +181,9 @@ public class SwerveChassis {
 
   /**
    * Sets strategy for azimuth flipping for all modules
-   * 
-   * @return
+   *
+   * @param supplier A lambda function of type ModuleDoubleSupplier. Takes a module, returns bias as
+   *     double
    */
   public void setAzimuthWrapBiasStrategy(ModuleDoubleSupplier supplier) {
     Stream.of(this.config.getModules()).forEach(m -> m.setAzimuthWrapBiasStrategy(supplier));
@@ -190,14 +191,15 @@ public class SwerveChassis {
 
   /**
    * Sets strategy for azimuth flipping for a single module
-   * 
-   * @return
+   *
+   * @param moduleIndex index of module to set
+   * @param supplier A lambda function of type ModuleDoubleSupplier. Takes a module, returns bias as
+   *     double
    */
   public void setAzimuthWrapBiasStrategy(int moduleIndex, ModuleDoubleSupplier supplier) {
-      SwerveModule module = this.config.getModules()[moduleIndex];
-      module.setAzimuthWrapBiasStrategy(supplier);
+    SwerveModule module = this.config.getModules()[moduleIndex];
+    module.setAzimuthWrapBiasStrategy(supplier);
   }
-
 
   /**
    * Gets the maximum translation speed if the drive is doing nothing else.

--- a/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
+++ b/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
@@ -114,8 +114,8 @@ public class ForwardKinematics {
                   double wheelVelocity = m.getWheelVelocity();
                   double azimuthPosition =
                       wheelVelocity < 0
-                          ? -m.getAzimuthPosition().asDouble()
-                          : m.getAzimuthPosition().asDouble();
+                          ? m.getAzimuthPosition().asDouble()
+                          : (m.getAzimuthPosition().asDouble() + 180.0);
                   return new ModuleState(azimuthPosition, Math.abs(wheelVelocity));
                 })
             .toArray(ModuleState[]::new);

--- a/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
+++ b/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
@@ -122,7 +122,7 @@ public class ForwardKinematics {
     VelocityState velState = calculateChassisVector(currentModuleStates);
     m_state.setVelocity(
         velState.getTranslationVector().getX(), velState.getTranslationVector().getY());
-    m_state.setThetaVelocity(velState.getRotationVelocity());
+    m_state.setThetaVelocity(Math.toDegrees(velState.getRotationVelocity()));
 
     estimatePoseExponential();
   }

--- a/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
+++ b/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
@@ -115,7 +115,7 @@ public class ForwardKinematics {
                   double azimuthPosition =
                       wheelVelocity < 0
                           ? m.getAzimuthPosition().asDouble()
-                          : (m.getAzimuthPosition().asDouble() + 180.0);
+                          : (m.getAzimuthPosition().asDouble());
                   return new ModuleState(azimuthPosition, Math.abs(wheelVelocity));
                 })
             .toArray(ModuleState[]::new);

--- a/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
+++ b/src/main/java/frc/team88/swerve/motion/kinematics/ForwardKinematics.java
@@ -112,10 +112,7 @@ public class ForwardKinematics {
             .map(
                 (m) -> {
                   double wheelVelocity = m.getWheelVelocity();
-                  double azimuthPosition =
-                      wheelVelocity < 0
-                          ? m.getAzimuthPosition().asDouble()
-                          : (m.getAzimuthPosition().asDouble());
+                  double azimuthPosition = m.getAzimuthPosition().asDouble();
                   return new ModuleState(azimuthPosition, Math.abs(wheelVelocity));
                 })
             .toArray(ModuleState[]::new);

--- a/src/main/java/frc/team88/swerve/util/WrappedAngle.java
+++ b/src/main/java/frc/team88/swerve/util/WrappedAngle.java
@@ -1,5 +1,6 @@
 package frc.team88.swerve.util;
 
+import edu.wpi.first.wpiutil.math.Pair;
 import java.util.Objects;
 
 /**
@@ -64,6 +65,34 @@ public class WrappedAngle {
       return difference + 360;
     } else {
       return difference - 360;
+    }
+  }
+
+  /**
+   * Gets the smallest difference (by magnitude) between this angle and either the given angle or
+   * the given angle + 180, going etiher clockwise or counter-clockwise.
+   *
+   * @param that The angle to get the difference from
+   * @param biasTo360 The maximum distance from the given angle where the distance returned will be
+   *     from it and not it + 180. Range is [0, 180], where 90 means indifference to where the given
+   *     angle or the given angle + 180 is used, 180 means never use the given angle + 180, and
+   *     anything less than 0.01 means always use the given angle + 180
+   * @return A javatuples pair containing (1) The difference, in degrees. When added to this angle,
+   *     the sum will be the given angle or the given angle + 180. (2) True adding the difference
+   *     will result in the given angle + 180, false if it will result in the given angle
+   */
+  public Pair<Double, Boolean> getSmallestDifferenceWithHalfAngle(
+      WrappedAngle that, double biasTo360) {
+    Objects.requireNonNull(that);
+    if (biasTo360 < 0 || biasTo360 > 180) {
+      throw new IllegalArgumentException("biasTo360 must be in range [0, 180]");
+    }
+    double differenceToFullAngle = getSmallestDifferenceWith(that);
+    if (Math.abs(differenceToFullAngle) > biasTo360 || biasTo360 < 0.01) {
+      return new Pair<Double, Boolean>(
+          getSmallestDifferenceWith(new WrappedAngle(that.asDouble() + 180)), true);
+    } else {
+      return new Pair<Double, Boolean>(differenceToFullAngle, false);
     }
   }
 


### PR DESCRIPTION
Add azimuth flip behavior. Allows for configurable flipping behavior when a module is told to change angle by a lot. By default, the module will reverse the wheel direction if the change is greater than 90, but this behavior can be changed with a lambda function.

This change was tested with pull request #118. Merge that pull request first before this one.